### PR TITLE
Add execution context stack for accessing caller information

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 R_DYNTRACE_HOME := ../R-dyntrace
 R_DYNTRACE := $(R_DYNTRACE_HOME)/bin/R
 R_CMD_CHECK_OUTPUT_DIRPATH := /tmp
+CLANG_TIDY := clang-tidy
 
 export R_ENABLE_JIT=0
 export R_DISABLE_BYTECODE=1
@@ -29,8 +30,10 @@ check: build
 test:
 	$(R_DYNTRACE) -e "devtools::test()"
 
-
 install-dependencies:
 	$(R_DYNTRACE) -e "install.packages(c('withr', 'testthat', 'devtools', 'roxygen2'), repos='http://cran.us.r-project.org')"
+
+analyze:
+	$(CLANG_TIDY) -checks='*,-fuchsia-default-arguments,-misc-unused-parameters,-misc-misplaced-const' -header-filter="^src/.*" -p . src/*.cpp
 
 .PHONY: all build install clean document check test install-dependencies

--- a/src/AnalysisDriver.cpp
+++ b/src/AnalysisDriver.cpp
@@ -1,10 +1,74 @@
 #include "AnalysisDriver.h"
 
 AnalysisDriver::AnalysisDriver(const Configuration &configuration)
-    : configuration_{configuration}, eval_expression_analysis_{configuration} {}
+    : configuration_{configuration},
+      execution_context_stack_{std::make_shared<ExecutionContextStack>()},
+      eval_expression_analysis_{configuration, execution_context_stack_} {}
+
+void AnalysisDriver::dyntrace_entry(const SEXP expression,
+                                    const SEXP environment) {
+
+    TopLevelExecutionContext context{environment};
+
+    if (configuration_.is_execution_context_stack_needed())
+        execution_context_stack_->push(context);
+}
+
+void AnalysisDriver::dyntrace_exit(const SEXP expression,
+                                   const SEXP environment, const SEXP result,
+                                   const int error) {
+
+    if (configuration_.is_execution_context_stack_needed())
+        execution_context_stack_->pop();
+}
 
 void AnalysisDriver::closure_entry(const SEXP call, const SEXP op,
                                    const SEXP args, const SEXP rho) {
+
+    FunctionExecutionContext context{call, op, args, rho};
+
+    if (configuration_.is_execution_context_stack_needed())
+        execution_context_stack_->push(context);
+
     if (configuration_.is_eval_expression_analysis_enabled())
-        eval_expression_analysis_.closure_entry(call, op, args, rho);
+        eval_expression_analysis_.closure_entry(context);
+}
+
+void AnalysisDriver::closure_exit(const SEXP call, const SEXP op,
+                                  const SEXP args, const SEXP rho,
+                                  const SEXP retval) {
+
+    if (configuration_.is_execution_context_stack_needed())
+        execution_context_stack_->pop();
+}
+
+void AnalysisDriver::builtin_entry(const SEXP call, const SEXP op,
+                                   const SEXP args, const SEXP rho) {
+
+    FunctionExecutionContext context{call, op, args, rho};
+    if (configuration_.is_execution_context_stack_needed())
+        execution_context_stack_->push(context);
+}
+
+void AnalysisDriver::builtin_exit(const SEXP call, const SEXP op,
+                                  const SEXP args, const SEXP rho,
+                                  const SEXP retval) {
+
+    if (configuration_.is_execution_context_stack_needed())
+        execution_context_stack_->pop();
+}
+
+void AnalysisDriver::special_entry(const SEXP call, const SEXP op,
+                                   const SEXP args, const SEXP rho) {
+
+    FunctionExecutionContext context{call, op, args, rho};
+    if (configuration_.is_execution_context_stack_needed())
+        execution_context_stack_->push(context);
+}
+
+void AnalysisDriver::special_exit(const SEXP call, const SEXP op,
+                                  const SEXP args, const SEXP rho,
+                                  const SEXP retval) {
+    if (configuration_.is_execution_context_stack_needed())
+        execution_context_stack_->pop();
 }

--- a/src/AnalysisDriver.cpp
+++ b/src/AnalysisDriver.cpp
@@ -41,6 +41,10 @@ void AnalysisDriver::closure_exit(const SEXP call, const SEXP op,
     ClosureExecutionContext context{
         std::get<ClosureExecutionContext>(execution_context_stack_->pop())};
     context.set_return_value(retval);
+
+    if (configuration_.is_eval_expression_analysis_enabled()) {
+        eval_expression_analysis_.closure_exit(context);
+    }
 }
 
 void AnalysisDriver::builtin_entry(const SEXP call, const SEXP op,
@@ -48,6 +52,10 @@ void AnalysisDriver::builtin_entry(const SEXP call, const SEXP op,
 
     BuiltinExecutionContext context{call, op, args, rho};
     execution_context_stack_->push(context);
+
+    if (configuration_.is_eval_expression_analysis_enabled()) {
+        eval_expression_analysis_.builtin_entry(context);
+    }
 }
 
 void AnalysisDriver::builtin_exit(const SEXP call, const SEXP op,
@@ -64,6 +72,10 @@ void AnalysisDriver::special_entry(const SEXP call, const SEXP op,
 
     SpecialExecutionContext context{call, op, args, rho};
     execution_context_stack_->push(context);
+
+    if (configuration_.is_eval_expression_analysis_enabled()) {
+        eval_expression_analysis_.special_entry(context);
+    }
 }
 
 void AnalysisDriver::special_exit(const SEXP call, const SEXP op,
@@ -88,4 +100,8 @@ void AnalysisDriver::context_jump(const RCNTXT *context,
                                   const SEXP return_value, int restart) {
     execution_contexts_t unwound_contexts{
         execution_context_stack_->unwind(RExecutionContext{context})};
+
+    if (configuration_.is_eval_expression_analysis_enabled()) {
+        eval_expression_analysis_.context_jump(unwound_contexts);
+    }
 }

--- a/src/AnalysisDriver.cpp
+++ b/src/AnalysisDriver.cpp
@@ -9,66 +9,83 @@ void AnalysisDriver::dyntrace_entry(const SEXP expression,
                                     const SEXP environment) {
 
     TopLevelExecutionContext context{environment};
-
-    if (configuration_.is_execution_context_stack_needed())
-        execution_context_stack_->push(context);
+    execution_context_stack_->push(context);
 }
 
 void AnalysisDriver::dyntrace_exit(const SEXP expression,
                                    const SEXP environment, const SEXP result,
                                    const int error) {
 
-    if (configuration_.is_execution_context_stack_needed())
-        execution_context_stack_->pop();
+    TopLevelExecutionContext context{
+        std::get<TopLevelExecutionContext>(execution_context_stack_->pop())};
+    context.set_result(result);
+    context.set_error(error);
 }
 
 void AnalysisDriver::closure_entry(const SEXP call, const SEXP op,
                                    const SEXP args, const SEXP rho) {
 
-    FunctionExecutionContext context{call, op, args, rho};
+    ClosureExecutionContext context{call, op, args, rho};
 
-    if (configuration_.is_execution_context_stack_needed())
-        execution_context_stack_->push(context);
-
-    if (configuration_.is_eval_expression_analysis_enabled())
+    if (configuration_.is_eval_expression_analysis_enabled()) {
         eval_expression_analysis_.closure_entry(context);
+    }
+
+    execution_context_stack_->push(context);
 }
 
 void AnalysisDriver::closure_exit(const SEXP call, const SEXP op,
                                   const SEXP args, const SEXP rho,
                                   const SEXP retval) {
 
-    if (configuration_.is_execution_context_stack_needed())
-        execution_context_stack_->pop();
+    ClosureExecutionContext context{
+        std::get<ClosureExecutionContext>(execution_context_stack_->pop())};
+    context.set_return_value(retval);
 }
 
 void AnalysisDriver::builtin_entry(const SEXP call, const SEXP op,
                                    const SEXP args, const SEXP rho) {
 
-    FunctionExecutionContext context{call, op, args, rho};
-    if (configuration_.is_execution_context_stack_needed())
-        execution_context_stack_->push(context);
+    BuiltinExecutionContext context{call, op, args, rho};
+    execution_context_stack_->push(context);
 }
 
 void AnalysisDriver::builtin_exit(const SEXP call, const SEXP op,
                                   const SEXP args, const SEXP rho,
                                   const SEXP retval) {
 
-    if (configuration_.is_execution_context_stack_needed())
-        execution_context_stack_->pop();
+    BuiltinExecutionContext context{
+        std::get<BuiltinExecutionContext>(execution_context_stack_->pop())};
+    context.set_return_value(retval);
 }
 
 void AnalysisDriver::special_entry(const SEXP call, const SEXP op,
                                    const SEXP args, const SEXP rho) {
 
-    FunctionExecutionContext context{call, op, args, rho};
-    if (configuration_.is_execution_context_stack_needed())
-        execution_context_stack_->push(context);
+    SpecialExecutionContext context{call, op, args, rho};
+    execution_context_stack_->push(context);
 }
 
 void AnalysisDriver::special_exit(const SEXP call, const SEXP op,
                                   const SEXP args, const SEXP rho,
                                   const SEXP retval) {
-    if (configuration_.is_execution_context_stack_needed())
-        execution_context_stack_->pop();
+    SpecialExecutionContext context{
+        std::get<SpecialExecutionContext>(execution_context_stack_->pop())};
+    context.set_return_value(retval);
+}
+
+void AnalysisDriver::context_entry(const RCNTXT *rcontext) {
+    RExecutionContext context{rcontext};
+    execution_context_stack_->push(context);
+}
+
+void AnalysisDriver::context_exit(const RCNTXT *rcontext) {
+    RExecutionContext context{
+        std::get<RExecutionContext>(execution_context_stack_->pop())};
+}
+
+void AnalysisDriver::context_jump(const RCNTXT *context,
+                                  const SEXP return_value, int restart) {
+    execution_contexts_t unwound_contexts{
+        execution_context_stack_->unwind(RExecutionContext{context})};
 }

--- a/src/AnalysisDriver.h
+++ b/src/AnalysisDriver.h
@@ -1,5 +1,5 @@
-#ifndef __ANALYSIS_DRIVER_H__
-#define __ANALYSIS_DRIVER_H__
+#ifndef EVALDYNTRACER_ANALYSIS_DRIVER_H
+#define EVALDYNTRACER_ANALYSIS_DRIVER_H
 
 #include "Configuration.h"
 #include "EvalExpressionAnalysis.h"
@@ -47,4 +47,4 @@ class AnalysisDriver {
     EvalExpressionAnalysis eval_expression_analysis_;
 };
 
-#endif /* __ANALYSIS_DRIVER_H__ */
+#endif /* EVALDYNTRACER_ANALYSIS_DRIVER_H */

--- a/src/AnalysisDriver.h
+++ b/src/AnalysisDriver.h
@@ -34,6 +34,13 @@ class AnalysisDriver {
     void special_exit(const SEXP call, const SEXP op, const SEXP args,
                       const SEXP rho, const SEXP retval);
 
+    void context_entry(const RCNTXT *rcontext);
+
+    void context_exit(const RCNTXT *rcontext);
+
+    void context_jump(const RCNTXT *context, const SEXP return_value,
+                      int restart);
+
   private:
     const Configuration configuration_;
     std::shared_ptr<ExecutionContextStack> execution_context_stack_;

--- a/src/AnalysisDriver.h
+++ b/src/AnalysisDriver.h
@@ -3,17 +3,40 @@
 
 #include "Configuration.h"
 #include "EvalExpressionAnalysis.h"
+#include "ExecutionContextStack.h"
 #include <memory>
 
 class AnalysisDriver {
 
   public:
     explicit AnalysisDriver(const Configuration &configuration);
+
+    void dyntrace_entry(const SEXP expression, const SEXP environment);
+
+    void dyntrace_exit(const SEXP expression, const SEXP environment,
+                       const SEXP result, const int error);
+
     void closure_entry(const SEXP call, const SEXP op, const SEXP args,
                        const SEXP rho);
 
+    void closure_exit(const SEXP call, const SEXP op, const SEXP args,
+                      const SEXP rho, const SEXP retval);
+
+    void builtin_entry(const SEXP call, const SEXP op, const SEXP args,
+                       const SEXP rho);
+
+    void builtin_exit(const SEXP call, const SEXP op, const SEXP args,
+                      const SEXP rho, const SEXP retval);
+
+    void special_entry(const SEXP call, const SEXP op, const SEXP args,
+                       const SEXP rho);
+
+    void special_exit(const SEXP call, const SEXP op, const SEXP args,
+                      const SEXP rho, const SEXP retval);
+
   private:
     const Configuration configuration_;
+    std::shared_ptr<ExecutionContextStack> execution_context_stack_;
     EvalExpressionAnalysis eval_expression_analysis_;
 };
 

--- a/src/BuiltinExecutionContext.h
+++ b/src/BuiltinExecutionContext.h
@@ -1,0 +1,17 @@
+#ifndef __BUILTIN_EXECUTION_CONTEXT_H__
+#define __BUILTIN_EXECUTION_CONTEXT_H__
+
+#include "FunctionExecutionContext.h"
+#include "sexptype.h"
+#include <Rinternals.h>
+
+class BuiltinExecutionContext : public FunctionExecutionContext {
+  public:
+    explicit BuiltinExecutionContext(const SEXP call, const SEXP op,
+                                     const SEXP args, const SEXP rho)
+        : FunctionExecutionContext{call, op, args, rho} {}
+
+    const sexptype_t get_type() const override { return BUILTINSXP; }
+};
+
+#endif /* __BUILTIN_EXECUTION_CONTEXT_H__ */

--- a/src/BuiltinExecutionContext.h
+++ b/src/BuiltinExecutionContext.h
@@ -1,5 +1,5 @@
-#ifndef __BUILTIN_EXECUTION_CONTEXT_H__
-#define __BUILTIN_EXECUTION_CONTEXT_H__
+#ifndef EVALDYNTRACER_BUILTIN_EXECUTION_CONTEXT_H
+#define EVALDYNTRACER_BUILTIN_EXECUTION_CONTEXT_H
 
 #include "FunctionExecutionContext.h"
 #include "sexptype.h"
@@ -14,4 +14,4 @@ class BuiltinExecutionContext : public FunctionExecutionContext {
     const sexptype_t get_type() const override { return BUILTINSXP; }
 };
 
-#endif /* __BUILTIN_EXECUTION_CONTEXT_H__ */
+#endif /* EVALDYNTRACER_BUILTIN_EXECUTION_CONTEXT_H */

--- a/src/ClosureExecutionContext.h
+++ b/src/ClosureExecutionContext.h
@@ -1,5 +1,5 @@
-#ifndef __CLOSURE_EXECUTION_CONTEXT_H__
-#define __CLOSURE_EXECUTION_CONTEXT_H__
+#ifndef EVALDYNTRACER_CLOSURE_EXECUTION_CONTEXT_H
+#define EVALDYNTRACER_CLOSURE_EXECUTION_CONTEXT_H
 
 #include "FunctionExecutionContext.h"
 #include "sexptype.h"
@@ -25,4 +25,4 @@ class ClosureExecutionContext : public FunctionExecutionContext {
     const sexptype_t get_type() const override { return CLOSXP; }
 };
 
-#endif /* __CLOSURE_EXECUTION_CONTEXT_H__ */
+#endif /* EVALDYNTRACER_CLOSURE_EXECUTION_CONTEXT_H */

--- a/src/ClosureExecutionContext.h
+++ b/src/ClosureExecutionContext.h
@@ -1,0 +1,28 @@
+#ifndef __CLOSURE_EXECUTION_CONTEXT_H__
+#define __CLOSURE_EXECUTION_CONTEXT_H__
+
+#include "FunctionExecutionContext.h"
+#include "sexptype.h"
+#include <Rinternals.h>
+
+class ClosureExecutionContext : public FunctionExecutionContext {
+  public:
+    explicit ClosureExecutionContext(const SEXP call, const SEXP op,
+                                     const SEXP args, const SEXP rho)
+        : FunctionExecutionContext{call, op, args, rho} {}
+
+    bool operator==(const ClosureExecutionContext &rhs) const {
+        return (get_call() == rhs.get_call() &&
+                get_function() == rhs.get_function() &&
+                get_arguments() == rhs.get_arguments() &&
+                get_environment() == rhs.get_environment());
+    }
+
+    bool operator!=(const ClosureExecutionContext &rhs) const {
+        return !(*this == rhs);
+    }
+
+    const sexptype_t get_type() const override { return CLOSXP; }
+};
+
+#endif /* __CLOSURE_EXECUTION_CONTEXT_H__ */

--- a/src/Configuration.h
+++ b/src/Configuration.h
@@ -1,5 +1,5 @@
-#ifndef __CONFIGURATION_H__
-#define __CONFIGURATION_H__
+#ifndef EVALDYNTRACER_CONFIGURATION_H
+#define EVALDYNTRACER_CONFIGURATION_H
 
 #include "Rincludes.h"
 #include "utilities.h"
@@ -99,4 +99,4 @@ class Configuration {
     std::string git_commit_info_;
 };
 
-#endif /* __CONFIGURATION_H__ */
+#endif /* EVALDYNTRACER_CONFIGURATION_H */

--- a/src/Configuration.h
+++ b/src/Configuration.h
@@ -6,25 +6,39 @@
 #include <sstream>
 #include <unordered_map>
 
+using eval_t = std::pair<std::string, SEXP>;
+
+inline std::string get_eval_name(const eval_t &eval) { return eval.first; }
+
+inline SEXP get_eval_function(const eval_t &eval) { return eval.second; }
+
 class Configuration {
   public:
     explicit Configuration(SEXP const evals, SEXP const raw_analysis_dirpath,
                            SEXP const analysis_flags, SEXP verbose)
-        : evals_{rlist_to_map<SEXP>(evals, identity<SEXP>)},
-          raw_analysis_dirpath_{rvector_to_string(raw_analysis_dirpath)},
+        : raw_analysis_dirpath_{rvector_to_string(raw_analysis_dirpath)},
           verbose_{rvector_to_bool(verbose)},
           enable_jit_{read_environment_variable("R_ENABLE_JIT")},
           compile_pkgs_{read_environment_variable("R_COMPILE_PKGS")},
           disable_bytecode_{read_environment_variable("R_DISABLE_BYTECODE")},
           git_commit_info_{GIT_COMMIT_INFO} {
+
+        transform_rlist(evals, [&](std::string name, SEXP function) {
+            evals_.push_back({name, function});
+        });
         std::unordered_map<std::string, bool> analysis_flags_{
             rlist_to_map<bool>(analysis_flags, rvector_to_bool)};
         eval_expression_analysis_enabled_ =
             analysis_flags_["eval_expression_analysis"];
     }
 
-    const std::unordered_map<std::string, SEXP> get_evals() const {
-        return evals_;
+    const std::optional<eval_t> get_eval_type(const SEXP function) const {
+        for (const auto &eval : evals_) {
+            if (eval.second == function) {
+                return eval;
+            }
+        }
+        return {};
     }
 
     bool is_eval_expression_analysis_enabled() const {
@@ -75,7 +89,7 @@ class Configuration {
     }
 
   private:
-    std::unordered_map<std::string, SEXP> evals_;
+    std::vector<eval_t> evals_;
     std::string raw_analysis_dirpath_;
     bool verbose_;
     bool eval_expression_analysis_enabled_;

--- a/src/Configuration.h
+++ b/src/Configuration.h
@@ -31,10 +31,6 @@ class Configuration {
         return eval_expression_analysis_enabled_;
     }
 
-    bool is_execution_context_stack_needed() const {
-        return eval_expression_analysis_enabled_;
-    }
-
     const std::string &get_raw_analysis_dirpath() const {
         return raw_analysis_dirpath_;
     }

--- a/src/Configuration.h
+++ b/src/Configuration.h
@@ -31,6 +31,10 @@ class Configuration {
         return eval_expression_analysis_enabled_;
     }
 
+    bool is_execution_context_stack_needed() const {
+        return eval_expression_analysis_enabled_;
+    }
+
     const std::string &get_raw_analysis_dirpath() const {
         return raw_analysis_dirpath_;
     }

--- a/src/EvalExpressionAnalysis.cpp
+++ b/src/EvalExpressionAnalysis.cpp
@@ -58,7 +58,8 @@ void EvalExpressionAnalysis::closure_exit(
     std::string filename;
 
     if (caller_function != nullptr) {
-        SourceLocation source_location{caller_function};
+        SourceLocation source_location{
+            SourceLocation::of_function(caller_function)};
         line_number = source_location.get_line_number();
         column_number = source_location.get_column_number();
         directory_path = source_location.get_directory_path().c_str();

--- a/src/EvalExpressionAnalysis.cpp
+++ b/src/EvalExpressionAnalysis.cpp
@@ -5,62 +5,115 @@ EvalExpressionAnalysis::EvalExpressionAnalysis(
     std::shared_ptr<ExecutionContextStack> execution_context_stack)
     : configuration_{configuration},
       execution_context_stack_{std::move(execution_context_stack)},
-      expression_table_writer_{configuration.get_raw_analysis_dirpath() + "/" +
-                                   "eval-expressions.tdf",
-                               {"eval_type", "caller", "caller_type",
-                                "callsite", "function", "expression_type",
-                                "expression"}} {}
+      expression_table_writer_{
+          configuration.get_raw_analysis_dirpath() + "/" +
+              "eval-expressions.tdf",
+          {"eval_type", "caller", "caller_type", "line_number", "column_number",
+           "directory_path", "filename", "callsite", "builtin", "special",
+           "closure", "expression_type", "expression"}},
+      opcounts_{} {}
 
 void EvalExpressionAnalysis::closure_entry(
     const ClosureExecutionContext &context) {
 
-    for (auto &key_value : configuration_.get_evals()) {
+    auto eval_type = configuration_.get_eval_type(context.get_function());
 
-        const std::string eval_name = key_value.first;
-        const SEXP eval_function = key_value.second;
+    if (eval_type) {
+        opcounts_.push_back({0, 0, 0});
+    } else {
+        std::for_each(opcounts_.begin(), opcounts_.end(),
+                      [](opcount_t &opcount) { opcount.closure_count++; });
+    }
+}
 
-        if (context.get_function() == eval_function) {
+void EvalExpressionAnalysis::closure_exit(
+    const ClosureExecutionContext &context) {
 
-            SEXP value = context.get_argument("expr", true);
+    auto eval_type = configuration_.get_eval_type(context.get_function());
 
-            if (value == R_UnboundValue) {
-                dyntrace_log_error(
-                    "'expr' not bound to a value in a call to '%s'",
-                    eval_name.c_str());
+    if (!eval_type) {
+        return;
+    }
+
+    std::string eval_name{get_eval_name(*eval_type)};
+
+    const opcount_t opcount{opcounts_.back()};
+    opcounts_.pop_back();
+
+    SEXP value = context.get_argument("expr", true);
+
+    if (value == R_UnboundValue) {
+        dyntrace_log_error("'expr' not bound to a value in a call to '%s'",
+                           eval_name.c_str());
+    }
+
+    sexptype_t type = TYPEOF(value);
+
+    const auto[caller_name, caller_type, caller_function] =
+        get_caller_information_();
+
+    unsigned int line_number = 0;
+    unsigned int column_number = 0;
+    std::string directory_path;
+    std::string filename;
+
+    if (caller_function != nullptr) {
+        SourceLocation source_location{caller_function};
+        line_number = source_location.get_line_number();
+        column_number = source_location.get_column_number();
+        directory_path = source_location.get_directory_path().c_str();
+        filename = source_location.get_filename().c_str();
+    }
+
+    expression_table_writer_.write_row(
+        eval_name, caller_name, sexptype_to_string(caller_type), line_number,
+        column_number, directory_path.c_str(), filename.c_str(),
+        std::string(serialize_sexp(context.get_call())), opcount.builtin_count,
+        opcount.special_count, opcount.closure_count, sexptype_to_string(type),
+        std::string(serialize_sexp(value)));
+}
+
+void EvalExpressionAnalysis::builtin_entry(
+    const BuiltinExecutionContext &context) {
+    std::for_each(opcounts_.begin(), opcounts_.end(),
+                  [](opcount_t &opcount) { opcount.builtin_count++; });
+}
+
+void EvalExpressionAnalysis::special_entry(
+    const SpecialExecutionContext &context) {
+    std::for_each(opcounts_.begin(), opcounts_.end(),
+                  [](opcount_t &opcount) { opcount.special_count++; });
+}
+
+void EvalExpressionAnalysis::context_jump(
+    const execution_contexts_t &unwound_contexts) {
+
+    for (auto iter = unwound_contexts.begin(); iter != unwound_contexts.end();
+         ++iter) {
+        if (std::holds_alternative<ClosureExecutionContext>(*iter)) {
+            if (configuration_.get_eval_type(
+                    std::get<ClosureExecutionContext>(*iter).get_function())) {
+                opcounts_.pop_back();
             }
-
-            sexptype_t type = TYPEOF(value);
-            SEXP function = R_NilValue;
-
-            if (type == LANGSXP) {
-                function = CAR(value);
-            }
-
-            const auto[caller_name, caller_type] = get_caller_information();
-
-            expression_table_writer_.write_row(
-                eval_name, caller_name, sexptype_to_string(caller_type),
-                std::string(serialize_sexp(context.get_call())),
-                std::string(serialize_sexp(function)), sexptype_to_string(type),
-                std::string(serialize_sexp(value)));
-
-            break;
         }
     }
 }
 
-std::tuple<std::string, sexptype_t>
-EvalExpressionAnalysis::get_caller_information() {
+std::tuple<std::string, sexptype_t, SEXP>
+EvalExpressionAnalysis::get_caller_information_() {
     std::string caller_name;
     sexptype_t caller_type;
+    SEXP caller_function = nullptr;
 
     auto last_context =
-        execution_context_stack_->get_last_execution_context(CLOSXP);
+        execution_context_stack_
+            ->get_last_execution_context<ClosureExecutionContext>(CLOSXP);
 
     if (last_context) {
-        auto closure_context = std::get<ClosureExecutionContext>(*last_context);
+        auto closure_context = *last_context;
         caller_name = closure_context.get_name();
         caller_type = closure_context.get_type();
+        caller_function = closure_context.get_function();
     } else {
         auto top_level_context =
             execution_context_stack_->get_top_level_execution_context();
@@ -68,5 +121,5 @@ EvalExpressionAnalysis::get_caller_information() {
         caller_type = top_level_context.get_type();
     }
 
-    return std::make_tuple(caller_name, caller_type);
+    return std::make_tuple(caller_name, caller_type, caller_function);
 }

--- a/src/EvalExpressionAnalysis.cpp
+++ b/src/EvalExpressionAnalysis.cpp
@@ -1,29 +1,54 @@
 #include "EvalExpressionAnalysis.h"
 
 EvalExpressionAnalysis::EvalExpressionAnalysis(
-    const Configuration &configuration)
+    const Configuration &configuration,
+    std::shared_ptr<ExecutionContextStack> execution_context_stack)
     : configuration_{configuration},
+      execution_context_stack_{execution_context_stack},
       expression_table_writer_{configuration.get_raw_analysis_dirpath() + "/" +
-                                   "eval-expressions.csv",
-                               {"function_name", "expression"}} {}
+                                   "eval-expressions.tdf",
+                               {"eval_type", "caller", "caller_type",
+                                "callsite", "function", "expression_type",
+                                "expression"}} {}
 
-void EvalExpressionAnalysis::closure_entry(const SEXP call, const SEXP op,
-                                           const SEXP args, const SEXP rho) {
+void EvalExpressionAnalysis::closure_entry(
+    const FunctionExecutionContext &context) {
+
     for (auto &key_value : configuration_.get_evals()) {
+
         const std::string eval_name = key_value.first;
         const SEXP eval_function = key_value.second;
-        if (op == eval_function) {
-            SEXP value = lookup_environment(rho, install("expr"));
-            if (value != R_UnboundValue) {
-                if (TYPEOF(value) == PROMSXP)
-                    value = get_promise_expression(value);
-                expression_table_writer_.write_row(eval_name,
-                                                   serialize_sexp(value));
-            } else {
+
+        if (context.get_function() == eval_function) {
+
+            SEXP value = context.get_argument("expr", true);
+
+            if (value == R_UnboundValue) {
                 dyntrace_log_error(
                     "'expr' not bound to a value in a call to '%s'",
                     eval_name.c_str());
             }
+
+            sexptype_t type = TYPEOF(value);
+            SEXP function = R_NilValue;
+
+            if (type == LANGSXP)
+                function = CAR(value);
+
+            const std::string caller_name{std::visit(
+                [](auto &&arg) -> std::string { return arg.get_name(); },
+                execution_context_stack_->peek())};
+
+            const std::string caller_type{sexptype_to_string(std::visit(
+                [](auto &&arg) -> sexptype_t { return arg.get_type(); },
+                execution_context_stack_->peek()))};
+
+            expression_table_writer_.write_row(
+                eval_name, caller_name, caller_type,
+                std::string(serialize_sexp(context.get_call())),
+                std::string(serialize_sexp(function)), sexptype_to_string(type),
+                std::string(serialize_sexp(value)));
+
             break;
         }
     }

--- a/src/EvalExpressionAnalysis.h
+++ b/src/EvalExpressionAnalysis.h
@@ -4,6 +4,7 @@
 #include "Configuration.h"
 #include "ExecutionContextStack.h"
 #include "Rincludes.h"
+#include "SourceLocation.h"
 #include "TableWriter.h"
 #include <memory>
 
@@ -13,13 +14,23 @@ class EvalExpressionAnalysis {
         const Configuration &configuration,
         std::shared_ptr<ExecutionContextStack> execution_context_stack);
     void closure_entry(const ClosureExecutionContext &context);
+    void closure_exit(const ClosureExecutionContext &context);
+    void builtin_entry(const BuiltinExecutionContext &context);
+    void special_entry(const SpecialExecutionContext &context);
+    void context_jump(const execution_contexts_t &unwound_contexts);
 
   private:
     const Configuration configuration_;
     const std::shared_ptr<ExecutionContextStack> execution_context_stack_;
     TableWriter expression_table_writer_;
+    std::tuple<std::string, sexptype_t, SEXP> get_caller_information_();
 
-    std::tuple<std::string, sexptype_t> get_caller_information();
+    struct opcount_t {
+        size_t closure_count;
+        size_t builtin_count;
+        size_t special_count;
+    };
+    std::vector<opcount_t> opcounts_;
 };
 
 #endif /* __EVAL_EXPRESSION_ANALYSIS_H__ */

--- a/src/EvalExpressionAnalysis.h
+++ b/src/EvalExpressionAnalysis.h
@@ -2,17 +2,21 @@
 #define __EVAL_EXPRESSION_ANALYSIS_H__
 
 #include "Configuration.h"
+#include "ExecutionContextStack.h"
 #include "Rincludes.h"
 #include "TableWriter.h"
+#include <memory>
 
 class EvalExpressionAnalysis {
   public:
-    explicit EvalExpressionAnalysis(const Configuration &configuration);
-    void closure_entry(const SEXP call, const SEXP op, const SEXP args,
-                       const SEXP rho);
+    explicit EvalExpressionAnalysis(
+        const Configuration &configuration,
+        std::shared_ptr<ExecutionContextStack> execution_context_stack);
+    void closure_entry(const FunctionExecutionContext &context);
 
   private:
     const Configuration configuration_;
+    const std::shared_ptr<ExecutionContextStack> execution_context_stack_;
     TableWriter expression_table_writer_;
 };
 

--- a/src/EvalExpressionAnalysis.h
+++ b/src/EvalExpressionAnalysis.h
@@ -12,12 +12,14 @@ class EvalExpressionAnalysis {
     explicit EvalExpressionAnalysis(
         const Configuration &configuration,
         std::shared_ptr<ExecutionContextStack> execution_context_stack);
-    void closure_entry(const FunctionExecutionContext &context);
+    void closure_entry(const ClosureExecutionContext &context);
 
   private:
     const Configuration configuration_;
     const std::shared_ptr<ExecutionContextStack> execution_context_stack_;
     TableWriter expression_table_writer_;
+
+    std::tuple<std::string, sexptype_t> get_caller_information();
 };
 
 #endif /* __EVAL_EXPRESSION_ANALYSIS_H__ */

--- a/src/EvalExpressionAnalysis.h
+++ b/src/EvalExpressionAnalysis.h
@@ -1,5 +1,5 @@
-#ifndef __EVAL_EXPRESSION_ANALYSIS_H__
-#define __EVAL_EXPRESSION_ANALYSIS_H__
+#ifndef EVALDYNTRACER_EVAL_EXPRESSION_ANALYSIS_H
+#define EVALDYNTRACER_EVAL_EXPRESSION_ANALYSIS_H
 
 #include "Configuration.h"
 #include "ExecutionContextStack.h"
@@ -33,4 +33,4 @@ class EvalExpressionAnalysis {
     std::vector<opcount_t> opcounts_;
 };
 
-#endif /* __EVAL_EXPRESSION_ANALYSIS_H__ */
+#endif /* EVALDYNTRACER_EVAL_EXPRESSION_ANALYSIS_H */

--- a/src/ExecutionContext.h
+++ b/src/ExecutionContext.h
@@ -1,0 +1,18 @@
+#ifndef __EXECUTION_CONTEXT_H__
+#define __EXECUTION_CONTEXT_H__
+
+#include "sexptype.h"
+#include <string>
+
+class ExecutionContext {
+  public:
+    explicit ExecutionContext() {}
+
+    virtual const sexptype_t get_type() const = 0;
+
+    virtual const std::string get_name() const = 0;
+
+    virtual ~ExecutionContext() {}
+};
+
+#endif /* __EXECUTION_CONTEXT_H__ */

--- a/src/ExecutionContext.h
+++ b/src/ExecutionContext.h
@@ -1,5 +1,5 @@
-#ifndef __EXECUTION_CONTEXT_H__
-#define __EXECUTION_CONTEXT_H__
+#ifndef EVALDYNTRACER_EXECUTION_CONTEXT_H
+#define EVALDYNTRACER_EXECUTION_CONTEXT_H
 
 #include "sexptype.h"
 #include <string>
@@ -15,4 +15,4 @@ class ExecutionContext {
     virtual ~ExecutionContext() {}
 };
 
-#endif /* __EXECUTION_CONTEXT_H__ */
+#endif /* EVALDYNTRACER_EXECUTION_CONTEXT_H */

--- a/src/ExecutionContextStack.h
+++ b/src/ExecutionContextStack.h
@@ -1,5 +1,5 @@
-#ifndef __EXECUTION_CONTEXT_STACK_H__
-#define __EXECUTION_CONTEXT_STACK_H__
+#ifndef EVALDYNTRACER_EXECUTION_CONTEXT_STACK_H
+#define EVALDYNTRACER_EXECUTION_CONTEXT_STACK_H
 
 #include "BuiltinExecutionContext.h"
 #include "ClosureExecutionContext.h"
@@ -91,4 +91,4 @@ class ExecutionContextStack {
     execution_contexts_t stack_;
 };
 
-#endif /* __EXECUTION_CONTEXT_STACK_H__ */
+#endif /* EVALDYNTRACER_EXECUTION_CONTEXT_STACK_H */

--- a/src/ExecutionContextStack.h
+++ b/src/ExecutionContextStack.h
@@ -47,7 +47,6 @@ class ExecutionContextStack {
             execution_context_t temp_context{pop()};
 
             if (std::holds_alternative<RExecutionContext>(temp_context)) {
-
                 if (context == std::get<RExecutionContext>(temp_context)) {
                     push(temp_context);
                     return unwound_contexts;
@@ -59,14 +58,17 @@ class ExecutionContextStack {
         dyntrace_log_error("cannot find matching execution context\n");
     }
 
-    std::optional<execution_context_t>
-    get_last_execution_context(sexptype_t type) const {
+    template <typename T>
+    std::optional<T> get_last_execution_context(sexptype_t type) const {
         sexptype_t current_type;
+
         for (const_reverse_iterator iter = crbegin(); iter != crend(); ++iter) {
+
             current_type = std::visit(
                 [](auto &&arg) -> sexptype_t { return arg.get_type(); }, *iter);
+
             if (current_type == type)
-                return *iter;
+                return std::get<T>(*iter);
         }
         return {};
     }

--- a/src/ExecutionContextStack.h
+++ b/src/ExecutionContextStack.h
@@ -1,0 +1,51 @@
+#ifndef __EXECUTION_CONTEXT_STACK_H__
+#define __EXECUTION_CONTEXT_STACK_H__
+
+#include "FunctionExecutionContext.h"
+#include "TopLevelExecutionContext.h"
+#include <variant>
+#include <vector>
+
+using execution_context_t =
+    std::variant<TopLevelExecutionContext, FunctionExecutionContext>;
+
+class ExecutionContextStack {
+    using execution_contexts_t = std::vector<execution_context_t>;
+
+  public:
+    using const_iterator = execution_contexts_t::const_iterator;
+
+    explicit ExecutionContextStack() : stack_{} {}
+
+    template <typename T> void push(const T &context) {
+        stack_.push_back(context);
+    }
+
+    execution_context_t pop() {
+        execution_context_t context{peek(1)};
+        stack_.pop_back();
+        return context;
+    }
+
+    execution_context_t peek(size_t n = 2) const {
+        n = stack_.size() - std::min(n, stack_.size());
+        return stack_[n];
+    }
+
+    std::vector<execution_context_t> unwind() { return {}; }
+
+    size_t size() const { return stack_.size(); }
+
+    const_iterator begin() const { return stack_.begin(); }
+
+    const_iterator end() const { return stack_.end(); }
+
+    const_iterator cbegin() const { return stack_.cbegin(); }
+
+    const_iterator cend() const { return stack_.cend(); }
+
+  private:
+    execution_contexts_t stack_;
+};
+
+#endif /* __EXECUTION_CONTEXT_STACK_H__ */

--- a/src/ExecutionContextStack.h
+++ b/src/ExecutionContextStack.h
@@ -1,19 +1,26 @@
 #ifndef __EXECUTION_CONTEXT_STACK_H__
 #define __EXECUTION_CONTEXT_STACK_H__
 
-#include "FunctionExecutionContext.h"
+#include "BuiltinExecutionContext.h"
+#include "ClosureExecutionContext.h"
+#include "RExecutionContext.h"
+#include "SpecialExecutionContext.h"
 #include "TopLevelExecutionContext.h"
+#include <optional>
 #include <variant>
 #include <vector>
 
 using execution_context_t =
-    std::variant<TopLevelExecutionContext, FunctionExecutionContext>;
+    std::variant<TopLevelExecutionContext, RExecutionContext,
+                 BuiltinExecutionContext, SpecialExecutionContext,
+                 ClosureExecutionContext>;
+
+using execution_contexts_t = std::vector<execution_context_t>;
 
 class ExecutionContextStack {
-    using execution_contexts_t = std::vector<execution_context_t>;
-
   public:
     using const_iterator = execution_contexts_t::const_iterator;
+    using const_reverse_iterator = execution_contexts_t::const_reverse_iterator;
 
     explicit ExecutionContextStack() : stack_{} {}
 
@@ -27,22 +34,56 @@ class ExecutionContextStack {
         return context;
     }
 
-    execution_context_t peek(size_t n = 2) const {
+    execution_context_t peek(size_t n = 1) const {
         n = stack_.size() - std::min(n, stack_.size());
         return stack_[n];
     }
 
-    std::vector<execution_context_t> unwind() { return {}; }
+    execution_contexts_t unwind(const RExecutionContext &context) {
+        execution_contexts_t unwound_contexts;
+
+        while (size() > 1) {
+
+            execution_context_t temp_context{pop()};
+
+            if (std::holds_alternative<RExecutionContext>(temp_context)) {
+
+                if (context == std::get<RExecutionContext>(temp_context)) {
+                    push(temp_context);
+                    return unwound_contexts;
+                }
+            }
+            unwound_contexts.push_back(temp_context);
+        }
+
+        dyntrace_log_error("cannot find matching execution context\n");
+    }
+
+    std::optional<execution_context_t>
+    get_last_execution_context(sexptype_t type) const {
+        sexptype_t current_type;
+        for (const_reverse_iterator iter = crbegin(); iter != crend(); ++iter) {
+            current_type = std::visit(
+                [](auto &&arg) -> sexptype_t { return arg.get_type(); }, *iter);
+            if (current_type == type)
+                return *iter;
+        }
+        return {};
+    }
+
+    TopLevelExecutionContext get_top_level_execution_context() const {
+        return std::get<TopLevelExecutionContext>(stack_[0]);
+    }
 
     size_t size() const { return stack_.size(); }
-
-    const_iterator begin() const { return stack_.begin(); }
-
-    const_iterator end() const { return stack_.end(); }
 
     const_iterator cbegin() const { return stack_.cbegin(); }
 
     const_iterator cend() const { return stack_.cend(); }
+
+    const_reverse_iterator crbegin() const { return stack_.crbegin(); }
+
+    const_reverse_iterator crend() const { return stack_.crend(); }
 
   private:
     execution_contexts_t stack_;

--- a/src/FunctionExecutionContext.h
+++ b/src/FunctionExecutionContext.h
@@ -1,20 +1,20 @@
 #ifndef __FUNCTION_EXECUTION_CONTEXT_H__
 #define __FUNCTION_EXECUTION_CONTEXT_H__
 
+#include "ExecutionContext.h"
 #include "sexptype.h"
 #include <Rinternals.h>
 
-class FunctionExecutionContext {
+class FunctionExecutionContext : public ExecutionContext {
   public:
     explicit FunctionExecutionContext(const SEXP call, const SEXP op,
                                       const SEXP args, const SEXP rho)
-        : call_{call}, op_{op}, args_{args}, rho_{rho} {}
+        : ExecutionContext{}, call_{call}, op_{op}, args_{args}, rho_{rho},
+          return_value_{nullptr} {}
 
     const SEXP get_call() const { return call_; }
 
     const SEXP get_function() const { return op_; }
-
-    const sexptype_t get_type() const { return TYPEOF(op_); }
 
     const SEXP get_arguments() const { return args_; }
 
@@ -31,15 +31,22 @@ class FunctionExecutionContext {
         return argument;
     }
 
-    const std::string get_name() const {
+    const std::string get_name() const override {
         return std::string(serialize_sexp(CAR(call_)));
     }
+
+    void set_return_value(SEXP return_value) { return_value_ = return_value; }
+
+    const SEXP get_return_value() const { return return_value_; }
+
+    virtual ~FunctionExecutionContext() {}
 
   private:
     const SEXP call_;
     const SEXP op_;
     const SEXP args_;
     const SEXP rho_;
+    SEXP return_value_;
 };
 
 #endif /* __FUNCTION_EXECUTION_CONTEXT_H__ */

--- a/src/FunctionExecutionContext.h
+++ b/src/FunctionExecutionContext.h
@@ -1,5 +1,5 @@
-#ifndef __FUNCTION_EXECUTION_CONTEXT_H__
-#define __FUNCTION_EXECUTION_CONTEXT_H__
+#ifndef EVALDYNTRACER_FUNCTION_EXECUTION_CONTEXT_H
+#define EVALDYNTRACER_FUNCTION_EXECUTION_CONTEXT_H
 
 #include "ExecutionContext.h"
 #include "sexptype.h"
@@ -49,4 +49,4 @@ class FunctionExecutionContext : public ExecutionContext {
     SEXP return_value_;
 };
 
-#endif /* __FUNCTION_EXECUTION_CONTEXT_H__ */
+#endif /* EVALDYNTRACER_FUNCTION_EXECUTION_CONTEXT_H */

--- a/src/FunctionExecutionContext.h
+++ b/src/FunctionExecutionContext.h
@@ -1,0 +1,45 @@
+#ifndef __FUNCTION_EXECUTION_CONTEXT_H__
+#define __FUNCTION_EXECUTION_CONTEXT_H__
+
+#include "sexptype.h"
+#include <Rinternals.h>
+
+class FunctionExecutionContext {
+  public:
+    explicit FunctionExecutionContext(const SEXP call, const SEXP op,
+                                      const SEXP args, const SEXP rho)
+        : call_{call}, op_{op}, args_{args}, rho_{rho} {}
+
+    const SEXP get_call() const { return call_; }
+
+    const SEXP get_function() const { return op_; }
+
+    const sexptype_t get_type() const { return TYPEOF(op_); }
+
+    const SEXP get_arguments() const { return args_; }
+
+    const SEXP get_environment() const { return rho_; }
+
+    const SEXP get_argument(std::string name, bool extract = false) const {
+        SEXP argument =
+            lookup_environment(get_environment(), install(name.c_str()));
+
+        if (extract)
+            while (TYPEOF(argument) == PROMSXP)
+                argument = get_promise_expression(argument);
+
+        return argument;
+    }
+
+    const std::string get_name() const {
+        return std::string(serialize_sexp(CAR(call_)));
+    }
+
+  private:
+    const SEXP call_;
+    const SEXP op_;
+    const SEXP args_;
+    const SEXP rho_;
+};
+
+#endif /* __FUNCTION_EXECUTION_CONTEXT_H__ */

--- a/src/Makevars
+++ b/src/Makevars
@@ -1,2 +1,2 @@
 GIT_COMMIT_INFO != git log --pretty=oneline -1
-PKG_CPPFLAGS = -I$(R_HOME)/src/include/ -DGIT_COMMIT_INFO='"$(GIT_COMMIT_INFO)"' --std=c++14
+PKG_CPPFLAGS = -I$(R_HOME)/src/include/ -DGIT_COMMIT_INFO='"$(GIT_COMMIT_INFO)"' --std=c++17

--- a/src/RExecutionContext.h
+++ b/src/RExecutionContext.h
@@ -1,5 +1,5 @@
-#ifndef __R_EXECUTION_CONTEXT_H__
-#define __R_EXECUTION_CONTEXT_H__
+#ifndef EVALDYNTRACER_R_EXECUTION_CONTEXT_H
+#define EVALDYNTRACER_R_EXECUTION_CONTEXT_H
 
 #include "ExecutionContext.h"
 #include "sexptype.h"
@@ -29,4 +29,4 @@ class RExecutionContext : public ExecutionContext {
     const RCNTXT *context_;
 };
 
-#endif /* __TOP_LEVEL_EXECUTION_CONTEXT_H__ */
+#endif /* EVALDYNTRACER_R_EXECUTION_CONTEXT_H */

--- a/src/RExecutionContext.h
+++ b/src/RExecutionContext.h
@@ -1,0 +1,32 @@
+#ifndef __R_EXECUTION_CONTEXT_H__
+#define __R_EXECUTION_CONTEXT_H__
+
+#include "ExecutionContext.h"
+#include "sexptype.h"
+#include <Rinternals.h>
+#include <string>
+
+class RExecutionContext : public ExecutionContext {
+  public:
+    explicit RExecutionContext(const RCNTXT *context)
+        : ExecutionContext{}, context_{context} {}
+
+    const sexptype_t get_type() const override { return RCNTXTSXP; }
+
+    const std::string get_name() const override { return "**r-context**"; }
+
+    const RCNTXT *get_context() const { return context_; }
+
+    bool operator==(const RExecutionContext &rhs) const {
+        return (get_context() == rhs.get_context());
+    }
+
+    bool operator!=(const RExecutionContext &rhs) const {
+        return !(*this == rhs);
+    }
+
+  private:
+    const RCNTXT *context_;
+};
+
+#endif /* __TOP_LEVEL_EXECUTION_CONTEXT_H__ */

--- a/src/Rincludes.h
+++ b/src/Rincludes.h
@@ -1,5 +1,5 @@
-#ifndef __R_INCLUDES_H__
-#define __R_INCLUDES_H__
+#ifndef EVALDYNTRACER_R_INCLUDES_H
+#define EVALDYNTRACER_R_INCLUDES_H
 
 #define USE_RINTERNALS
 #include <Rinternals.h>
@@ -17,4 +17,4 @@
 #include <Defn.h>
 #include <Rdyntrace.h>
 
-#endif /* __R_INCLUDES_H__ */
+#endif /* EVALDYNTRACER_R_INCLUDES_H */

--- a/src/Rincludes.h
+++ b/src/Rincludes.h
@@ -1,11 +1,6 @@
 #ifndef __R_INCLUDES_H__
 #define __R_INCLUDES_H__
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-  //#include <R.h>
 #define USE_RINTERNALS
 #include <Rinternals.h>
 #undef TRUE
@@ -21,9 +16,5 @@ extern "C" {
 
 #include <Defn.h>
 #include <Rdyntrace.h>
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif /* __R_INCLUDES_H__ */

--- a/src/SourceLocation.cpp
+++ b/src/SourceLocation.cpp
@@ -1,0 +1,90 @@
+#include "SourceLocation.h"
+
+SourceLocation SourceLocation::of_function(SEXP function, SEXP environment) {
+    return SourceLocation(get_line_number_(function, environment),
+                          get_column_number_(function, environment),
+                          get_directory_path_(function, environment),
+                          get_filename_(function, environment));
+}
+
+unsigned int SourceLocation::get_line_number_(SEXP function, SEXP environment) {
+    dyntrace_enable_privileged_mode();
+
+    SEXP line_number_sexp;
+    unsigned int line_number;
+
+    PROTECT(line_number_sexp =
+                Rf_eval(lang3(install("getSrcLocation"), function,
+                              ScalarString(mkChar("line"))),
+                        environment));
+
+    if (LENGTH(line_number_sexp) > 0)
+        line_number = index_integer_rvector(line_number_sexp);
+
+    UNPROTECT(1);
+
+    dyntrace_disable_privileged_mode();
+
+    return line_number;
+}
+
+unsigned int SourceLocation::get_column_number_(SEXP function,
+                                                SEXP environment) {
+    dyntrace_enable_privileged_mode();
+
+    SEXP column_number_sexp;
+    unsigned int column_number;
+
+    PROTECT(column_number_sexp =
+                Rf_eval(lang3(install("getSrcLocation"), function,
+                              ScalarString(mkChar("column"))),
+                        environment));
+
+    if (LENGTH(column_number_sexp) > 0)
+        column_number = index_integer_rvector(column_number_sexp);
+
+    UNPROTECT(1);
+
+    dyntrace_disable_privileged_mode();
+
+    return column_number;
+}
+
+std::string SourceLocation::get_directory_path_(SEXP function,
+                                                SEXP environment) {
+    dyntrace_enable_privileged_mode();
+
+    SEXP directory_path_sexp;
+    std::string directory_path;
+
+    PROTECT(directory_path_sexp = Rf_eval(
+                lang2(install("getSrcDirectory"), function), environment));
+
+    if (LENGTH(directory_path_sexp) > 0)
+        directory_path = index_character_rvector(directory_path_sexp);
+
+    UNPROTECT(1);
+
+    dyntrace_disable_privileged_mode();
+
+    return directory_path;
+}
+
+std::string SourceLocation::get_filename_(SEXP function, SEXP environment) {
+    dyntrace_enable_privileged_mode();
+
+    SEXP filename_sexp;
+    std::string filename;
+
+    PROTECT(filename_sexp = Rf_eval(lang2(install("getSrcFilename"), function),
+                                    environment));
+
+    if (LENGTH(filename_sexp) > 0)
+        filename = index_character_rvector(filename_sexp);
+
+    UNPROTECT(1);
+
+    dyntrace_disable_privileged_mode();
+
+    return filename;
+}

--- a/src/SourceLocation.h
+++ b/src/SourceLocation.h
@@ -1,0 +1,60 @@
+#ifndef EVALDYNTRACER_SOURCE_LOCATION_H
+#define EVALDYNTRACER_SOURCE_LOCATION_H
+
+#include "Rincludes.h"
+#include "utilities.h"
+
+class SourceLocation {
+  public:
+    explicit SourceLocation(SEXP function, SEXP environment = R_GlobalEnv)
+        : line_number_{0}, column_number_{0}, directory_path_{""},
+          filename_{""} {
+        dyntrace_enable_privileged_mode();
+
+        SEXP line_number;
+        PROTECT(line_number = Rf_eval(lang3(install("getSrcLocation"), function,
+                                            ScalarString(mkChar("line"))),
+                                      environment));
+        if (LENGTH(line_number) > 0)
+            line_number_ = index_integer_rvector(line_number);
+
+        SEXP column_number;
+        PROTECT(column_number =
+                    Rf_eval(lang3(install("getSrcLocation"), function,
+                                  ScalarString(mkChar("column"))),
+                            environment));
+        if (LENGTH(column_number) > 0)
+            column_number_ = index_integer_rvector(column_number);
+
+        SEXP directory_path;
+        PROTECT(directory_path = Rf_eval(
+                    lang2(install("getSrcDirectory"), function), environment));
+        if (LENGTH(directory_path) > 0)
+            directory_path_ = index_character_rvector(directory_path);
+
+        SEXP filename;
+        PROTECT(filename = Rf_eval(lang2(install("getSrcFilename"), function),
+                                   environment));
+        if (LENGTH(filename) > 0)
+            filename_ = index_character_rvector(filename);
+
+        UNPROTECT(4);
+        dyntrace_disable_privileged_mode();
+    }
+
+    unsigned int get_line_number() const { return line_number_; }
+
+    unsigned int get_column_number() const { return column_number_; }
+
+    const std::string &get_directory_path() const { return directory_path_; }
+
+    const std::string &get_filename() const { return filename_; }
+
+  private:
+    unsigned int line_number_;
+    unsigned int column_number_;
+    std::string directory_path_;
+    std::string filename_;
+};
+
+#endif /* EVALDYNTRACER_SOURCE_LOCATION_H */

--- a/src/SpecialExecutionContext.h
+++ b/src/SpecialExecutionContext.h
@@ -1,5 +1,5 @@
-#ifndef __SPECIAL_EXECUTION_CONTEXT_H__
-#define __SPECIAL_EXECUTION_CONTEXT_H__
+#ifndef EVALDYNTRACER_SPECIAL_EXECUTION_CONTEXT_H
+#define EVALDYNTRACER_SPECIAL_EXECUTION_CONTEXT_H
 
 #include "FunctionExecutionContext.h"
 #include "sexptype.h"
@@ -14,4 +14,4 @@ class SpecialExecutionContext : public FunctionExecutionContext {
     const sexptype_t get_type() const override { return SPECIALSXP; }
 };
 
-#endif /* __SPECIAL_EXECUTION_CONTEXT_H__ */
+#endif /* EVALDYNTRACER_SPECIAL_EXECUTION_CONTEXT_H */

--- a/src/SpecialExecutionContext.h
+++ b/src/SpecialExecutionContext.h
@@ -1,0 +1,17 @@
+#ifndef __SPECIAL_EXECUTION_CONTEXT_H__
+#define __SPECIAL_EXECUTION_CONTEXT_H__
+
+#include "FunctionExecutionContext.h"
+#include "sexptype.h"
+#include <Rinternals.h>
+
+class SpecialExecutionContext : public FunctionExecutionContext {
+  public:
+    explicit SpecialExecutionContext(const SEXP call, const SEXP op,
+                                     const SEXP args, const SEXP rho)
+        : FunctionExecutionContext{call, op, args, rho} {}
+
+    const sexptype_t get_type() const override { return SPECIALSXP; }
+};
+
+#endif /* __SPECIAL_EXECUTION_CONTEXT_H__ */

--- a/src/State.h
+++ b/src/State.h
@@ -1,5 +1,5 @@
-#ifndef __STATE_H__
-#define __STATE_H__
+#ifndef EVALDYNTRACER_STATE_H
+#define EVALDYNTRACER_STATE_H
 
 #include "AnalysisDriver.h"
 #include "Configuration.h"
@@ -19,4 +19,4 @@ class State {
     std::unique_ptr<AnalysisDriver> analysis_driver_;
 };
 
-#endif /* __STATE_H__ */
+#endif /* EVALDYNTRACER_STATE_H */

--- a/src/TableWriter.h
+++ b/src/TableWriter.h
@@ -1,5 +1,5 @@
-#ifndef __TABLE_WRITER_H__
-#define __TABLE_WRITER_H__
+#ifndef EVALDYNTRACER_TABLE_WRITER_H
+#define EVALDYNTRACER_TABLE_WRITER_H
 
 #include "Configuration.h"
 #include "Rincludes.h"
@@ -70,4 +70,4 @@ class TableWriter {
     static const std::string row_separator_;
 };
 
-#endif /* __TABLE_WRITER_H__ */
+#endif /* EVALDYNTRACER_TABLE_WRITER_H */

--- a/src/TopLevelExecutionContext.h
+++ b/src/TopLevelExecutionContext.h
@@ -1,23 +1,35 @@
 #ifndef __TOP_LEVEL_EXECUTION_CONTEXT_H__
 #define __TOP_LEVEL_EXECUTION_CONTEXT_H__
 
+#include "ExecutionContext.h"
 #include "sexptype.h"
 #include <Rinternals.h>
 #include <string>
 
-class TopLevelExecutionContext {
+class TopLevelExecutionContext : public ExecutionContext {
   public:
     explicit TopLevelExecutionContext(const SEXP environment)
-        : environment_{environment} {}
+        : ExecutionContext{}, environment_{environment}, result_{nullptr},
+          error_{0} {}
 
-    const std::string get_name() const { return std::string("**top-level**"); }
+    const sexptype_t get_type() const override { return TOPLEVELSXP; }
 
-    const sexptype_t get_type() const { return TOPLEVELSXP; }
+    const std::string get_name() const override { return "**top-level**"; }
 
     const SEXP get_environment() const { return environment_; }
 
+    void set_result(SEXP result) { result_ = result; }
+
+    const SEXP get_result() const { return result_; }
+
+    void set_error(int error) { error_ = error; }
+
+    int get_error() const { return error_; }
+
   private:
     const SEXP environment_;
+    SEXP result_;
+    int error_;
 };
 
 #endif /* __TOP_LEVEL_EXECUTION_CONTEXT_H__ */

--- a/src/TopLevelExecutionContext.h
+++ b/src/TopLevelExecutionContext.h
@@ -1,5 +1,5 @@
-#ifndef __TOP_LEVEL_EXECUTION_CONTEXT_H__
-#define __TOP_LEVEL_EXECUTION_CONTEXT_H__
+#ifndef EVALDYNTRACER_TOP_LEVEL_EXECUTION_CONTEXT_H
+#define EVALDYNTRACER_TOP_LEVEL_EXECUTION_CONTEXT_H
 
 #include "ExecutionContext.h"
 #include "sexptype.h"
@@ -32,4 +32,4 @@ class TopLevelExecutionContext : public ExecutionContext {
     int error_;
 };
 
-#endif /* __TOP_LEVEL_EXECUTION_CONTEXT_H__ */
+#endif /* EVALDYNTRACER_TOP_LEVEL_EXECUTION_CONTEXT_H */

--- a/src/TopLevelExecutionContext.h
+++ b/src/TopLevelExecutionContext.h
@@ -1,0 +1,23 @@
+#ifndef __TOP_LEVEL_EXECUTION_CONTEXT_H__
+#define __TOP_LEVEL_EXECUTION_CONTEXT_H__
+
+#include "sexptype.h"
+#include <Rinternals.h>
+#include <string>
+
+class TopLevelExecutionContext {
+  public:
+    explicit TopLevelExecutionContext(const SEXP environment)
+        : environment_{environment} {}
+
+    const std::string get_name() const { return std::string("**top-level**"); }
+
+    const sexptype_t get_type() const { return TOPLEVELSXP; }
+
+    const SEXP get_environment() const { return environment_; }
+
+  private:
+    const SEXP environment_;
+};
+
+#endif /* __TOP_LEVEL_EXECUTION_CONTEXT_H__ */

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1,10 +1,10 @@
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <R_ext/Rdynload.h>
 #include <R_ext/Visibility.h>
 #include "tracer.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 static const R_CallMethodDef CallEntries[] = {
   {"create_dyntracer", (DL_FUNC) &create_dyntracer, 4},

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1,21 +1,20 @@
+#include "tracer.h"
 #include <R_ext/Rdynload.h>
 #include <R_ext/Visibility.h>
-#include "tracer.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 static const R_CallMethodDef CallEntries[] = {
-  {"create_dyntracer", (DL_FUNC) &create_dyntracer, 4},
-  {"destroy_dyntracer", (DL_FUNC) &destroy_dyntracer, 1},
-  {NULL, NULL, 0}
-};
+    {"create_dyntracer", (DL_FUNC)&create_dyntracer, 4},
+    {"destroy_dyntracer", (DL_FUNC)&destroy_dyntracer, 1},
+    {NULL, NULL, 0}};
 
 void attribute_visible R_init_evaldyntracer(DllInfo *dll) {
-  R_registerRoutines(dll, NULL, CallEntries, NULL, NULL);
-  R_useDynamicSymbols(dll, FALSE);
-  R_forceSymbols(dll, TRUE);
+    R_registerRoutines(dll, NULL, CallEntries, NULL, NULL);
+    R_useDynamicSymbols(dll, FALSE);
+    R_forceSymbols(dll, TRUE);
 }
 
 #ifdef __cplusplus

--- a/src/probes.cpp
+++ b/src/probes.cpp
@@ -1,13 +1,19 @@
 #include "probes.h"
 
-void probe_dyntrace_entry(dyntracer_t *dyntracer, SEXP expression,
-                          SEXP environment) {
+void probe_dyntrace_entry(dyntracer_t *dyntracer, const SEXP expression,
+                          const SEXP environment) {
     verbose_log_info(configuration(dyntracer).is_verbose(), "\n%s",
                      std::string(configuration(dyntracer)).c_str());
+
+    analysis_driver(dyntracer).dyntrace_entry(expression, environment);
 }
 
-void probe_dyntrace_exit(dyntracer_t *dyntracer, SEXP expression,
-                         SEXP environment, SEXP result, int error) {}
+void probe_dyntrace_exit(dyntracer_t *dyntracer, const SEXP expression,
+                         const SEXP environment, const SEXP result,
+                         const int error) {
+    analysis_driver(dyntracer).dyntrace_exit(expression, environment, result,
+                                             error);
+}
 
 void probe_closure_entry(dyntracer_t *dyntracer, const SEXP call, const SEXP op,
                          const SEXP args, const SEXP rho) {
@@ -15,19 +21,29 @@ void probe_closure_entry(dyntracer_t *dyntracer, const SEXP call, const SEXP op,
 }
 
 void probe_closure_exit(dyntracer_t *dyntracer, const SEXP call, const SEXP op,
-                        const SEXP args, const SEXP rho, const SEXP retval) {}
+                        const SEXP args, const SEXP rho, const SEXP retval) {
+    analysis_driver(dyntracer).closure_exit(call, op, args, rho, retval);
+}
 
 void probe_builtin_entry(dyntracer_t *dyntracer, const SEXP call, const SEXP op,
-                         const SEXP args, const SEXP rho) {}
+                         const SEXP args, const SEXP rho) {
+    analysis_driver(dyntracer).builtin_entry(call, op, args, rho);
+}
 
 void probe_builtin_exit(dyntracer_t *dyntracer, const SEXP call, const SEXP op,
-                        const SEXP args, const SEXP rho, const SEXP retval) {}
+                        const SEXP args, const SEXP rho, const SEXP retval) {
+    analysis_driver(dyntracer).builtin_exit(call, op, args, rho, retval);
+}
 
 void probe_special_entry(dyntracer_t *dyntracer, const SEXP call, const SEXP op,
-                         const SEXP args, const SEXP rho) {}
+                         const SEXP args, const SEXP rho) {
+    analysis_driver(dyntracer).special_entry(call, op, args, rho);
+}
 
 void probe_special_exit(dyntracer_t *dyntracer, const SEXP call, const SEXP op,
-                        const SEXP args, const SEXP rho, const SEXP retval) {}
+                        const SEXP args, const SEXP rho, const SEXP retval) {
+    analysis_driver(dyntracer).special_exit(call, op, args, rho, retval);
+}
 
 void probe_promise_force_entry(dyntracer_t *dyntracer, const SEXP promise) {}
 

--- a/src/probes.cpp
+++ b/src/probes.cpp
@@ -81,12 +81,18 @@ void probe_gc_unmark(dyntracer_t *dyntracer, const SEXP object) {}
 
 void probe_gc_allocate(dyntracer_t *dyntracer, const SEXP object) {}
 
-void probe_context_entry(dyntracer_t *dyntracer, const RCNTXT *context) {}
+void probe_context_entry(dyntracer_t *dyntracer, const RCNTXT *context) {
+    analysis_driver(dyntracer).context_entry(context);
+}
 
-void probe_context_exit(dyntracer_t *dyntracer, const RCNTXT *context) {}
+void probe_context_exit(dyntracer_t *dyntracer, const RCNTXT *context) {
+    analysis_driver(dyntracer).context_exit(context);
+}
 
 void probe_context_jump(dyntracer_t *dyntracer, const RCNTXT *context,
-                        const SEXP return_value, int restart) {}
+                        const SEXP return_value, int restart) {
+    analysis_driver(dyntracer).context_jump(context, return_value, restart);
+}
 
 void probe_S3_generic_entry(dyntracer_t *dyntracer, const char *generic,
                             const SEXP object) {}

--- a/src/probes.h
+++ b/src/probes.h
@@ -1,5 +1,5 @@
-#ifndef __PROBES_H__
-#define __PROBES_H__
+#ifndef EVALDYNTRACER_PROBES_H
+#define EVALDYNTRACER_PROBES_H
 
 #define R_INLINES_H_
 #include "State.h"
@@ -114,4 +114,4 @@ void probe_environment_variable_lookup(dyntracer_t *dyntracer,
 void probe_environment_variable_exists(dyntracer_t *dyntracer,
                                        const SEXP symbol, const SEXP rho);
 
-#endif /* __PROBES_H__ */
+#endif /* EVALDYNTRACER_PROBES_H */

--- a/src/probes.h
+++ b/src/probes.h
@@ -14,11 +14,12 @@ inline AnalysisDriver &analysis_driver(dyntracer_t *dyntracer) {
     return static_cast<State *>(dyntracer->state)->get_analysis_driver();
 }
 
-void probe_dyntrace_entry(dyntracer_t *dyntracer, SEXP expression,
-                          SEXP environment);
+void probe_dyntrace_entry(dyntracer_t *dyntracer, const SEXP expression,
+                          const SEXP environment);
 
-void probe_dyntrace_exit(dyntracer_t *dyntracer, SEXP expression,
-                         SEXP environment, SEXP result, int error);
+void probe_dyntrace_exit(dyntracer_t *dyntracer, const SEXP expression,
+                         const SEXP environment, const SEXP result,
+                         const int error);
 
 void probe_closure_entry(dyntracer_t *dyntracer, const SEXP call, const SEXP op,
                          const SEXP args, const SEXP rho);

--- a/src/sexptype.h
+++ b/src/sexptype.h
@@ -1,5 +1,5 @@
-#ifndef __SEXPTYPE_H__
-#define __SEXPTYPE_H__
+#ifndef EVALDYNTRACER_SEXPTYPE_H
+#define EVALDYNTRACER_SEXPTYPE_H
 
 #include <Rinternals.h>
 
@@ -29,4 +29,4 @@ inline std::string sexptype_to_string(const sexptype_t sexptype) {
     }
 }
 
-#endif /* __SEXPTYPE_H__ */
+#endif /* EVALDYNTRACER_SEXPTYPE_H */

--- a/src/sexptype.h
+++ b/src/sexptype.h
@@ -3,9 +3,10 @@
 
 #include <Rinternals.h>
 
-typedef int sexptype_t;
+using sexptype_t = int;
 
 const int TOPLEVELSXP = 10001;
+const int RCNTXTSXP = 10002;
 
 inline std::string sexptype_to_string(const sexptype_t sexptype) {
     switch (sexptype) {

--- a/src/sexptype.h
+++ b/src/sexptype.h
@@ -1,0 +1,31 @@
+#ifndef __SEXPTYPE_H__
+#define __SEXPTYPE_H__
+
+#include <Rinternals.h>
+
+typedef int sexptype_t;
+
+const int TOPLEVELSXP = 10001;
+
+inline std::string sexptype_to_string(const sexptype_t sexptype) {
+    switch (sexptype) {
+        case TOPLEVELSXP:
+            return "Top Level";
+        case NILSXP:
+            return "Null";
+        case LANGSXP:
+            return "Function Call";
+        case NEWSXP:
+            return "New";
+        case FREESXP:
+            return "Free";
+        case FUNSXP:
+            return "Closure or Builtin";
+        default:
+            std::string str(type2char(sexptype));
+            str[0] = std::toupper(str[0]);
+            return str;
+    }
+}
+
+#endif /* __SEXPTYPE_H__ */

--- a/src/tracer.cpp
+++ b/src/tracer.cpp
@@ -8,7 +8,8 @@ SEXP create_dyntracer(SEXP evals, SEXP raw_analysis_dirpath,
     /* calloc initializes the memory to zero. This ensures that probes not
        attached will be NULL. Replacing calloc with malloc will cause
        segfaults. */
-    dyntracer_t *dyntracer = (dyntracer_t *)calloc(1, sizeof(dyntracer_t));
+    auto dyntracer = static_cast<dyntracer_t *>(calloc(1, sizeof(dyntracer_t)));
+
     dyntracer->state = new State(
         Configuration(evals, raw_analysis_dirpath, analysis_flags, verbose));
 
@@ -62,8 +63,8 @@ static void destroy_evaldyntracer(dyntracer_t *dyntracer) {
     /* free dyntracer iff it has not already been freed.
        this check ensures that multiple calls to destroy_dyntracer on the same
        object do not crash the process. */
-    if (dyntracer) {
-        State *state = static_cast<State *>(dyntracer->state);
+    if (dyntracer != nullptr) {
+        auto state = static_cast<State *>(dyntracer->state);
         delete state;
         free(dyntracer);
     }

--- a/src/tracer.h
+++ b/src/tracer.h
@@ -1,11 +1,11 @@
 #ifndef __TRACER_H__
 #define __TRACER_H__
 
+#include "Rincludes.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include "Rincludes.h"
 
 SEXP create_dyntracer(SEXP evals, SEXP raw_analysis_dirpath,
                       SEXP analysis_flags, SEXP verbose);

--- a/src/tracer.h
+++ b/src/tracer.h
@@ -1,5 +1,5 @@
-#ifndef __TRACER_H__
-#define __TRACER_H__
+#ifndef EVALDYNTRACER_TRACER_H
+#define EVALDYNTRACER_TRACER_H
 
 #include "Rincludes.h"
 
@@ -16,4 +16,4 @@ SEXP destroy_dyntracer(SEXP dyntracer);
 }
 #endif
 
-#endif /* __TRACER_H__ */
+#endif /* EVALDYNTRACER_TRACER_H */

--- a/src/utilities.h
+++ b/src/utilities.h
@@ -1,5 +1,5 @@
-#ifndef __UTILITIES_H__
-#define __UTILITIES_H__
+#ifndef EVALDYNTRACER_UTILITIES_H
+#define EVALDYNTRACER_UTILITIES_H
 
 #include "Rincludes.h"
 #include <cstdlib>
@@ -72,4 +72,4 @@ transform_rlist(SEXP rlist,
     }
 }
 
-#endif /* __UTILITIES_H__ **/
+#endif /* EVALDYNTRACER_UTILITIES_H */

--- a/src/utilities.h
+++ b/src/utilities.h
@@ -21,6 +21,11 @@ inline int index_real_rvector(const SEXP rvector, size_t index = 0) {
     return REAL(rvector)[index];
 }
 
+inline unsigned int index_integer_rvector(const SEXP rvector,
+                                          size_t index = 0) {
+    return INTEGER(rvector)[index];
+}
+
 inline std::string index_character_rvector(const SEXP rvector,
                                            size_t index = 0) {
     return std::string(CHAR(STRING_ELT(rvector, index)));
@@ -55,6 +60,16 @@ rlist_to_map(SEXP rlist, std::function<Value(SEXP)> transformer) {
             transformer(VECTOR_ELT(rlist, index));
     }
     return mapping;
+}
+
+inline void
+transform_rlist(SEXP rlist,
+                std::function<void(std::string, SEXP)> accumulator) {
+    SEXP keys = getAttrib(rlist, R_NamesSymbol);
+    for (int index = 0; index < LENGTH(rlist); ++index) {
+        accumulator(index_character_rvector(keys, index),
+                    VECTOR_ELT(rlist, index));
+    }
 }
 
 #endif /* __UTILITIES_H__ **/

--- a/tests/testthat/test-eval-expression-analysis.R
+++ b/tests/testthat/test-eval-expression-analysis.R
@@ -27,46 +27,46 @@ test_that_in_temp_dir("eval expression analysis captures all members of the 'eva
         local(x + y)
     }, analysis_dirpath, verbose = FALSE)
 
-    eval_expression_table <- read.csv(file.path(analysis_dirpath, "eval-expressions.csv"),
+    eval_expression_table <- read.csv(file.path(analysis_dirpath, "eval-expressions.tdf"),
                                       sep = "#",
                                       stringsAsFactors = FALSE)
 
     expect_gte(nrow(eval_expression_table), 9)
 
     expect_equal(nrow(subset(eval_expression_table,
-                             function_name == "base::eval" &
+                             eval_type == "base::eval" &
                              expression == "quote(1 + 2 + 3)")), 1)
 
     expect_equal(nrow(subset(eval_expression_table,
-                             function_name == "base::eval" &
+                             eval_type == "base::eval" &
                              expression == "quote(eval.parent(evalq(x + y)))")), 1)
 
     expect_equal(nrow(subset(eval_expression_table,
-                             function_name == "base::eval" &
+                             eval_type == "base::eval" &
                              expression == "quote(eval.parent(get(paste0(a, b))) + eval(5))")), 1)
 
     expect_equal(nrow(subset(eval_expression_table,
-                             function_name == "base::eval" &
+                             eval_type == "base::eval" &
                              expression == "5")), 1)
 
     expect_equal(nrow(subset(eval_expression_table,
-                             function_name == "base::evalq" &
+                             eval_type == "base::evalq" &
                              expression == "a")), 1)
 
     expect_equal(nrow(subset(eval_expression_table,
-                             function_name == "base::evalq" &
+                             eval_type == "base::evalq" &
                              expression == "x + y")), 1)
 
     expect_equal(nrow(subset(eval_expression_table,
-                             function_name == "base::eval.parent" &
+                             eval_type == "base::eval.parent" &
                              expression == "evalq(x + y)")), 1)
 
     expect_equal(nrow(subset(eval_expression_table,
-                             function_name == "base::eval.parent" &
+                             eval_type == "base::eval.parent" &
                              expression == "get(paste0(a, b))")), 1)
 
     expect_equal(nrow(subset(eval_expression_table,
-                             function_name == "base::local" &
+                             eval_type == "base::local" &
                              expression == "x + y")), 1)
 })
 
@@ -91,45 +91,45 @@ test_that_in_temp_dir("eval expression analysis captures aliased members of the 
         bl(x + y)
     }, analysis_dirpath, verbose = FALSE)
 
-    eval_expression_table <- read.csv(file.path(analysis_dirpath, "eval-expressions.csv"),
+    eval_expression_table <- read.csv(file.path(analysis_dirpath, "eval-expressions.tdf"),
                                       sep = "#",
                                       stringsAsFactors = FALSE)
 
     expect_gte(nrow(eval_expression_table), 9)
 
     expect_equal(nrow(subset(eval_expression_table,
-                             function_name == "base::eval" &
+                             eval_type == "base::eval" &
                              expression == "quote(1 + 2 + 3)")), 1)
 
     expect_equal(nrow(subset(eval_expression_table,
-                             function_name == "base::eval" &
+                             eval_type == "base::eval" &
                              expression == "quote(bep(beq(x + y)))")), 1)
 
     expect_equal(nrow(subset(eval_expression_table,
-                             function_name == "base::eval" &
+                             eval_type == "base::eval" &
                              expression == "quote(bep(get(paste0(a, b))) + be(5))")), 1)
 
     expect_equal(nrow(subset(eval_expression_table,
-                             function_name == "base::eval" &
+                             eval_type == "base::eval" &
                              expression == "5")), 1)
 
     expect_equal(nrow(subset(eval_expression_table,
-                             function_name == "base::evalq" &
+                             eval_type == "base::evalq" &
                              expression == "a")), 1)
 
     expect_equal(nrow(subset(eval_expression_table,
-                             function_name == "base::evalq" &
+                             eval_type == "base::evalq" &
                              expression == "x + y")), 1)
 
     expect_equal(nrow(subset(eval_expression_table,
-                             function_name == "base::eval.parent" &
+                             eval_type == "base::eval.parent" &
                              expression == "beq(x + y)")), 1)
 
     expect_equal(nrow(subset(eval_expression_table,
-                             function_name == "base::eval.parent" &
+                             eval_type == "base::eval.parent" &
                              expression == "get(paste0(a, b))")), 1)
 
     expect_equal(nrow(subset(eval_expression_table,
-                             function_name == "base::local" &
+                             eval_type == "base::local" &
                              expression == "x + y")), 1)
 })


### PR DESCRIPTION
This commit adds an execution context stack to the tracer.
Every time a closure, builtin or special is entered, a
context is pushed on the stack and on exiting from the function
the context is popped.

This provides access to the entire call chain. This can be used
to get information such as the caller of the currently entered
function or the parent environment.

eval expression analysis has also been updated to utilize the
stack and get the caller of the eval function.